### PR TITLE
Bump dependencies so OWASP check passes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,6 +30,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -37,10 +38,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
+			<version>2.0.5</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+			<version>1.4.7</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -53,7 +56,7 @@
 		<dependency>
 			<groupId>org.apache.santuario</groupId>
 			<artifactId>xmlsec</artifactId>
-			<version>2.3.0</version>
+			<version>3.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -65,19 +68,19 @@
 		<dependency>
 			<groupId>com.azure</groupId>
 			<artifactId>azure-security-keyvault-keys</artifactId>
-			<version>4.3.4</version>
+			<version>4.6.3</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.4.2</version>
+			<version>2.15.2</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.azure</groupId>
 			<artifactId>azure-identity</artifactId>
-			<version>1.3.7</version>
+			<version>1.9.2</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>
@@ -87,7 +90,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.7</version>
+				<version>0.8.10</version>
 				<configuration>
 					<propertyName>jacoco.agent.argLine</propertyName>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>6.3.1</version>
+				<version>8.3.1</version>
 				<configuration>
 					<failBuildOnCVSS>7</failBuildOnCVSS>
 					<suppressionFiles>
@@ -120,7 +120,7 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.8.1</version>
+					<version>3.11.0</version>
 					<configuration>
 						<source>1.8</source>
 						<target>1.8</target>
@@ -129,7 +129,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.0.1</version>
 					<configuration>
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<useReleaseProfile>false</useReleaseProfile>
@@ -187,7 +187,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-						<version>3.2.1</version>
+						<version>3.3.0</version>
 						<executions>
 							<execution>
 								<id>attach-sources</id>
@@ -216,7 +216,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>3.0.1</version>
+						<version>3.1.0</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/servlet-jakarta/pom.xml
+++ b/servlet-jakarta/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>jakarta.servlet</groupId>
 			<artifactId>jakarta.servlet-api</artifactId>
-			<version>5.0.0</version>
+			<version>6.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -50,6 +50,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/servlet-javax/pom.xml
+++ b/servlet-javax/pom.xml
@@ -50,7 +50,8 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<scope>test</scope>
+			<version>1.10.19</version>
+            <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/toolkit/pom.xml
+++ b/toolkit/pom.xml
@@ -43,6 +43,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -50,10 +51,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
+			<version>2.0.5</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+			<version>1.4.7</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -66,7 +69,7 @@
 		<dependency>
 			<groupId>org.apache.santuario</groupId>
 			<artifactId>xmlsec</artifactId>
-			<version>2.2.3</version>
+			<version>3.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>


### PR DESCRIPTION
$ mvn clean install
...
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:6.3.1:check (default) on project java-saml-core: [ERROR]
[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': [ERROR]
[ERROR] accessors-smart-2.4.7.jar: CVE-2022-45688
[ERROR] jackson-core-2.13.4.jar: CVE-2022-45688
[ERROR] json-smart-2.4.7.jar: CVE-2023-1370
[ERROR] netty-codec-4.1.68.Final.jar: CVE-2022-41881 [ERROR] netty-transport-4.1.68.Final.jar: CVE-2022-41881 [ERROR] stax2-api-4.2.1.jar: CVE-2022-40152
[ERROR] woodstox-core-6.2.6.jar/META-INF/maven/com.sun.xml.bind.jaxb/isorelax/pom.xml: CVE-2023-34411 [ERROR] woodstox-core-6.2.6.jar: CVE-2022-40152